### PR TITLE
Add Docker build and compose setup

### DIFF
--- a/.env.container.example
+++ b/.env.container.example
@@ -1,0 +1,4 @@
+# Example settings for running the application with Docker Compose
+OPENAI_KEY=sk-your-openai-api-key
+# Chroma data is stored inside the container at /app/db (bound to the chroma_data volume)
+CHROMA_DB_PATH=/app/db

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# Example settings for running the scripts directly on your machine
+OPENAI_KEY=sk-your-openai-api-key
+# Path where Chroma will persist the vector store when running locally
+CHROMA_DB_PATH=./db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.22-bullseye AS builder
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o vector-launcher ./
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY --from=builder /app/vector-launcher ./vector-launcher
+COPY add_documents.py add_documents_bdd_tests.py bdd_tests.feature ./
+
+ENV CHROMA_DB_DIR=/app/db
+VOLUME ["/app/db"]
+
+ENTRYPOINT ["./vector-launcher"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,38 @@
-to run the scripts make sure you have installed all deps with: 
-`pip install behave chromadb python-dotenv`
+# Persistant Vector DB
 
-to run tests run: 
-`behave`
+## Local development
+
+1. Copy `.env.local.example` to `.env` and update the values with your own credentials.
+2. Install the Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the Behave tests when you need to exercise the existing BDD scenarios:
+   ```bash
+   behave
+   ```
+
+## Container workflow
+
+The repository includes a multi-stage Docker build that compiles the Go launcher and installs the Python dependencies required by the scripts.
+
+### Build the image
+
+```bash
+docker build -t persistant-vector-db .
+```
+
+### Run with Docker Compose
+
+1. Copy `.env.container.example` to `.env` and set `OPENAI_KEY` (Docker Compose automatically reads `.env`).
+2. Start the stack with a persistent Chroma volume:
+   ```bash
+   docker compose up
+   ```
+
+The compose file binds a named volume to `/app/db` so your Chroma collections survive container restarts. The `OPENAI_KEY` environment variable is injected into the container at runtime.
+
+## Environment files
+
+- `.env.local.example` – template for running the scripts directly on your machine.
+- `.env.container.example` – template for container-based workflows; copy to `.env` before running `docker compose`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Persistant Vector DB
+# Persistent Vector DB
 
 ## Local development
 
@@ -19,7 +19,7 @@ The repository includes a multi-stage Docker build that compiles the Go launcher
 ### Build the image
 
 ```bash
-docker build -t persistant-vector-db .
+docker build -t persistent-vector-db .
 ```
 
 ### Run with Docker Compose

--- a/add_documents.py
+++ b/add_documents.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     try:
         # Check if three command-line arguments are provided
         if len(sys.argv) != 4:
-            raise ValueError("Usage: python script.py <documents> <metadatas> <ids>")
+            raise ValueError("Usage: python add_documents.py <documents> <metadatas> <ids>")
 
         # Extract the command-line arguments as strings
         documents = sys.argv[1]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    build: .
+    image: persistant-vector-db:latest
+    env_file:
+      - .env
+    environment:
+      - OPENAI_KEY=${OPENAI_KEY}
+    volumes:
+      - chroma_data:/app/db
+    restart: unless-stopped
+volumes:
+  chroma_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   app:
     build: .
-    image: persistant-vector-db:latest
+    image: persistent-vector-db:latest
     env_file:
       - .env
     environment:

--- a/main.go
+++ b/main.go
@@ -16,7 +16,13 @@ func main() {
 	}
 
 	// Prepare the command to execute the Python script
-	cmd := exec.Command("python3", "script.py", `["Tomatoes, onions, baby potatoes, cabbage, cabbage leaves", "jolof rice"]`, `[{"topic": "ingredients_list"}, {"topic": "favourite_recipes"}]`, `["id1", "id2"]`)
+	cmd := exec.Command(
+		"python3",
+		"add_documents.py",
+		"[\"Tomatoes, onions, baby potatoes, cabbage, cabbage leaves\", \"jolof rice\"]",
+		"[{\"topic\": \"ingredients_list\"}, {\"topic\": \"favourite_recipes\"}]",
+		"[\"id1\", \"id2\"]",
+	)
 
 	// Set the working directory if needed (optional)
 	// cmd.Dir = "/path/to/python_script_directory"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+chromadb
+behave
+python-dotenv
+openai


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that compiles the Go launcher and installs the Python dependencies
- add docker-compose configuration with a persistent Chroma volume and OPENAI_KEY injection
- document container workflows and provide example environment files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42c12cc408328bea2942763428c3f