### PR TITLE
Refactor ingestion helpers and expand tests

### DIFF
--- a/add_documents.py
+++ b/add_documents.py
@@ -1,18 +1,30 @@
-import chromadb
-from chromadb.utils import embedding_functions
-from dotenv import load_dotenv
-import os
-import sys
+"""Utilities for ingesting documents into a Chroma collection."""
 
-def load_openai_key():
-    # Load variables from .env file into environment
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, List, Sequence
+import os
+
+
+class IngestionError(ValueError):
+    """Raised when the ingestion payload is invalid."""
+
+
+def load_openai_key() -> str:
+    """Load the OpenAI API key from the environment."""
+
+    from dotenv import load_dotenv
+
     load_dotenv()
-    openai_key = os.environ.get('OPENAI_KEY')
+    openai_key = os.environ.get("OPENAI_KEY")
     if not openai_key:
         raise ValueError("OPENAI_KEY is not set in the .env file.")
     return openai_key
 
 def create_openai_ef(api_key):
+    from chromadb.utils import embedding_functions
+
     # Using OpenAI Embeddings. This assumes you have the openai package installed
     openai_ef = embedding_functions.OpenAIEmbeddingFunction(
         api_key=api_key,
@@ -20,51 +32,128 @@ def create_openai_ef(api_key):
     )
     return openai_ef
 
-def create_or_get_collection(client):
-    # Create a new chroma collection
-    collection_name = "lake"
-    return client.get_or_create_collection(name=collection_name)
+def get_persistent_client(persist_directory: str = "db") -> Any:
+    """Return a persistent Chroma client for the provided directory."""
 
-def add_to_openai_collection(collection, documents, metadatas, ids):
-    try:
-        collection.add(
-            documents=documents,
-            metadatas=metadatas,
-            ids=ids
+    import chromadb
+
+    return chromadb.PersistentClient(path=persist_directory)
+
+
+def create_or_get_collection(client: Any, name: str = "lake") -> Any:
+    """Create a new chroma collection or return an existing one."""
+
+    return client.get_or_create_collection(name=name)
+
+
+def _ensure_sequence(data: Sequence, expected_length: int, label: str) -> List:
+    if isinstance(data, (str, bytes)) or not isinstance(data, Sequence):
+        raise IngestionError(f"{label} must be a sequence of values.")
+
+    values = list(data)
+    if len(values) != expected_length:
+        raise IngestionError(
+            f"Expected {expected_length} {label}, received {len(values)}."
         )
-        print("Documents added to the collection successfully.")
-    except Exception as e:
-        print(f"Error occurred while adding documents: {e}")
+    return values
 
-if __name__ == "__main__":
-    try:
-        # Check if three command-line arguments are provided
-        if len(sys.argv) != 4:
-            raise ValueError("Usage: python script.py <documents> <metadatas> <ids>")
 
-        # Extract the command-line arguments as strings
-        documents = sys.argv[1]
-        metadatas = sys.argv[2]
-        ids = sys.argv[3]
+def ingest_documents(
+    collection,
+    documents: Sequence[str],
+    metadatas: Sequence[dict],
+    ids: Sequence[str],
+) -> int:
+    """Add the provided documents to the collection.
 
-        # Create a new Chroma client with persistence enabled.
-        persist_directory = "db" # this path for the db could be an arg 
-        client = chromadb.PersistentClient(path=persist_directory)
+    Args:
+        collection: A Chroma collection (or any object exposing an ``add`` method).
+        documents: Sequence of textual documents.
+        metadatas: Sequence of metadata dictionaries.
+        ids: Sequence of unique document identifiers.
 
-        # Load the OpenAI key
-        openai_key = load_openai_key()
+    Returns:
+        The number of documents ingested.
 
-        # Create/Open OpenAI Embedding Function
-        openai_ef = create_openai_ef(api_key=openai_key)
+    Raises:
+        IngestionError: If the provided payload is invalid.
+    """
 
-        # Create or get the Chroma collection
-        openai_collection = create_or_get_collection(client)
+    document_list = list(documents)
+    metadata_list = _ensure_sequence(metadatas, len(document_list), "metadatas")
+    id_list = _ensure_sequence(ids, len(document_list), "ids")
 
-        # Call the function with the provided arguments
-        add_to_openai_collection(openai_collection, documents, metadatas, ids)
-    except ValueError as ve:
-        print(ve)
-    except chromadb.ChromaDBError as cde:
-        print(f"ChromaDBError: {cde}")
-    except Exception as e:
-        print(f"An unexpected error occurred: {e}")
+    if not all(isinstance(doc, str) for doc in document_list):
+        raise IngestionError("All documents must be strings.")
+
+    if not all(isinstance(meta, dict) for meta in metadata_list):
+        raise IngestionError("All metadatas must be dictionaries.")
+
+    if not all(isinstance(id_value, str) for id_value in id_list):
+        raise IngestionError("All ids must be strings.")
+
+    if len(set(id_list)) != len(id_list):
+        raise IngestionError("Duplicate ids detected in payload.")
+
+    collection.add(documents=document_list, metadatas=metadata_list, ids=id_list)
+    return len(document_list)
+
+
+def parse_ingestion_payload(payload: str | dict) -> tuple[List[str], List[dict], List[str]]:
+    """Parse a JSON payload into document, metadata, and id lists."""
+
+    if isinstance(payload, str):
+        try:
+            payload_data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise IngestionError("Invalid JSON payload provided.") from exc
+    elif isinstance(payload, dict):
+        payload_data = payload
+    else:
+        raise IngestionError("Payload must be a JSON string or dictionary.")
+
+    required_keys = {"documents", "metadatas", "ids"}
+    missing_keys = required_keys.difference(payload_data)
+    if missing_keys:
+        missing = ", ".join(sorted(missing_keys))
+        raise IngestionError(f"Payload is missing required keys: {missing}.")
+
+    documents = payload_data["documents"]
+    metadatas = payload_data["metadatas"]
+    ids = payload_data["ids"]
+
+    if not isinstance(documents, list):
+        raise IngestionError("Payload field 'documents' must be a list.")
+    if not isinstance(metadatas, list):
+        raise IngestionError("Payload field 'metadatas' must be a list.")
+    if not isinstance(ids, list):
+        raise IngestionError("Payload field 'ids' must be a list.")
+
+    return documents, metadatas, ids
+
+
+def run_ingestion(
+    documents: Iterable[str],
+    metadatas: Iterable[dict],
+    ids: Iterable[str],
+    *,
+    persist_directory: str = "db",
+    collection_name: str = "lake",
+) -> int:
+    """Convenience helper to ingest a batch of documents."""
+
+    client = get_persistent_client(persist_directory=persist_directory)
+    collection = create_or_get_collection(client, name=collection_name)
+    return ingest_documents(collection, documents, metadatas, ids)
+
+
+__all__ = [
+    "IngestionError",
+    "create_openai_ef",
+    "create_or_get_collection",
+    "get_persistent_client",
+    "ingest_documents",
+    "load_openai_key",
+    "parse_ingestion_payload",
+    "run_ingestion",
+]

--- a/bdd_tests.feature
+++ b/bdd_tests.feature
@@ -4,5 +4,55 @@ Feature: Adding documents to the OpenAI collection
     Given the OpenAI key is set in the .env file
     And an OpenAI Embedding Function is created
     And a Chroma client with persistence enabled is available
-    When documents, metadatas, and ids are provided
+    When the following documents are ingested
+      | document              | metadata                                 | id    |
+      | First lake document   | {"source": "behave", "category": "test"} | doc-1 |
+      | Second lake document  | {"source": "behave"}                     | doc-2 |
     Then the documents should be added to the collection successfully
+
+  Scenario: Failing when duplicate ids are provided
+    Given the OpenAI key is set in the .env file
+    And an OpenAI Embedding Function is created
+    And a Chroma client with persistence enabled is available
+    When the following documents are ingested
+      | document              | metadata                                 | id    |
+      | Duplicate lake entry  | {"source": "behave"}                     | doc-1 |
+      | Duplicate lake entry  | {"source": "behave"}                     | doc-1 |
+    Then an error should be raised containing "Duplicate ids"
+
+  Scenario: Failing when metadata JSON is invalid
+    Given the OpenAI key is set in the .env file
+    And an OpenAI Embedding Function is created
+    And a Chroma client with persistence enabled is available
+    When the following documents are ingested
+      | document             | metadata     | id    |
+      | Broken metadata doc  | {not-json}   | doc-3 |
+    Then an ingestion error should be raised
+
+  Scenario: Failing when payload JSON is invalid
+    Given the OpenAI key is set in the .env file
+    And an OpenAI Embedding Function is created
+    And a Chroma client with persistence enabled is available
+    When the payload is ingested
+      """
+      {invalid
+      """
+    Then an error should be raised containing "Invalid JSON payload provided."
+
+  Scenario: Failing when required payload keys are missing
+    Given the OpenAI key is set in the .env file
+    And an OpenAI Embedding Function is created
+    And a Chroma client with persistence enabled is available
+    When the payload is ingested
+      """
+      {
+        "documents": ["Only document"],
+        "metadatas": [{"source": "behave"}]
+      }
+      """
+    Then an error should be raised containing "Payload is missing required keys"
+
+  Scenario: Failing when the OpenAI key is missing
+    Given the OpenAI key is not set in the environment
+    When I load the OpenAI key
+    Then an error should be raised containing "OPENAI_KEY is not set"

--- a/tests/test_add_documents.py
+++ b/tests/test_add_documents.py
@@ -1,0 +1,84 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from add_documents import IngestionError, ingest_documents, parse_ingestion_payload
+
+
+class DummyCollection:
+    def __init__(self):
+        self.items = {}
+
+    def add(self, documents, metadatas, ids):
+        for doc, metadata, doc_id in zip(documents, metadatas, ids):
+            if doc_id in self.items:
+                raise ValueError("ID already exists")
+            self.items[doc_id] = {"document": doc, "metadata": metadata}
+
+    def remove(self, ids):
+        for doc_id in ids:
+            self.items.pop(doc_id, None)
+
+    def __len__(self):
+        return len(self.items)
+
+
+@pytest.fixture()
+def collection():
+    return DummyCollection()
+
+
+def test_parse_ingestion_payload_success():
+    payload = {
+        "documents": ["Doc"],
+        "metadatas": [{"source": "unit"}],
+        "ids": ["doc-1"],
+    }
+
+    documents, metadatas, ids = parse_ingestion_payload(payload)
+
+    assert documents == ["Doc"]
+    assert metadatas == [{"source": "unit"}]
+    assert ids == ["doc-1"]
+
+
+@pytest.mark.parametrize(
+    "payload, expected_message",
+    [
+        ("{invalid", "Invalid JSON payload provided."),
+        (
+            {"documents": ["Doc"], "metadatas": [{"source": "unit"}]},
+            "Payload is missing required keys",
+        ),
+    ],
+)
+def test_parse_ingestion_payload_errors(payload, expected_message):
+    with pytest.raises(IngestionError) as exc_info:
+        parse_ingestion_payload(payload)
+
+    assert expected_message in str(exc_info.value)
+
+
+def test_ingest_documents_success(collection):
+    documents = ["Doc 1", "Doc 2"]
+    metadatas = [{"source": "unit"}, {"source": "unit"}]
+    ids = ["doc-1", "doc-2"]
+
+    ingested = ingest_documents(collection, documents, metadatas, ids)
+
+    assert ingested == 2
+    assert len(collection) == 2
+
+
+def test_ingest_documents_duplicate_ids(collection):
+    documents = ["Doc 1", "Doc 2"]
+    metadatas = [{"source": "unit"}, {"source": "unit"}]
+    ids = ["doc-1", "doc-1"]
+
+    with pytest.raises(IngestionError) as exc_info:
+        ingest_documents(collection, documents, metadatas, ids)
+
+    assert "Duplicate ids" in str(exc_info.value)

--- a/tests/test_add_documents.py
+++ b/tests/test_add_documents.py
@@ -3,8 +3,6 @@ import sys
 
 import pytest
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-
 from add_documents import IngestionError, ingest_documents, parse_ingestion_payload
 
 


### PR DESCRIPTION
## Summary
- refactor the ingestion module into reusable helpers with stronger validation
- update Behave steps and scenarios to provide structured payloads and cover negative cases
- add pytest unit tests to exercise payload parsing and ingestion logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e42c0f3c5c83288826a82290ba83c0